### PR TITLE
Update github publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           dotnet-version: '8'
       - name: Publish
-        run: dotnet publish
+        run: dotnet publish sync-video-subtitle-name.csproj
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
@@ -37,7 +37,7 @@ jobs:
         with:
           dotnet-version: '8'
       - name: Publish
-        run: dotnet publish
+        run: dotnet publish sync-video-subtitle-name.csproj
       - name: Upload
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Publish main project only, excluding test csproj.
This might help decrease build time.